### PR TITLE
Consolidate PDF/MIME type detection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -96,6 +96,11 @@
             <artifactId>util-test</artifactId>
             <version>1.4.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>2.0.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>util-graphicsmagick</artifactId>
     <name>GraphicsMagic Util</name>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
 
     <properties>
         <target>1.8</target>

--- a/src/main/java/com/afrozaar/util/graphicsmagick/AbstractImageIO.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/AbstractImageIO.java
@@ -1,6 +1,7 @@
 package com.afrozaar.util.graphicsmagick;
 
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
 
 import com.google.common.io.ByteSource;
 
@@ -64,8 +65,8 @@ public abstract class AbstractImageIO implements IImageService {
     }
 
     protected String getTempFileName(String sourceName) {
-        String suffix = getExtension(sourceName);
-        return tempDir + File.separator + "resource_" + getRandomAlpha(5) + (suffix == null ? "" : suffix.toLowerCase());
+        String suffix = ofNullable(getExtension(sourceName)).map(String::toLowerCase).orElse("");
+        return format("%s%sresource_%s%s", tempDir, File.separator, getRandomAlpha(5), suffix) ;
     }
 
     protected String getExtension(String imageName) {

--- a/src/main/java/com/afrozaar/util/graphicsmagick/IMimeService.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/IMimeService.java
@@ -1,0 +1,11 @@
+package com.afrozaar.util.graphicsmagick;
+
+import java.io.IOException;
+
+public interface IMimeService {
+
+    /**
+     * Simple MIME inspector that interrogates the specified file for its MIME type.
+     */
+    String getMimeType(String uri) throws IOException;
+}

--- a/src/main/java/com/afrozaar/util/graphicsmagick/MimeService.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/MimeService.java
@@ -1,0 +1,52 @@
+package com.afrozaar.util.graphicsmagick;
+
+import static java.lang.String.format;
+
+import com.google.common.io.ByteSource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+public class MimeService implements IMimeService {
+
+    /**
+     * {@inheritDoc}
+     *
+     * This Implementation makes use of the Unix Command 'file' to determine the MIME type.
+     */
+    @Override
+    public String getMimeType(final String uri) throws IOException {
+
+        // $ file -i gm.tar.bz2
+        final String[] fileCmd = { "file", "-i", uri };
+
+        try {
+            final Process process = Runtime.getRuntime().exec(fileCmd);
+
+            if (process.waitFor(3, TimeUnit.SECONDS)) {
+                //        gm.tar.bz2: application/x-bzip2; charset=binary
+                String output = new String(new ByteSource() {
+                    @Override
+                    public InputStream openStream() throws IOException {
+                        return process.getInputStream();
+                    }
+                }.read());
+                return output.split(":")[1].split(";")[0].trim();
+            } else {
+
+                String error = new String(new ByteSource() {
+                    @Override
+                    public InputStream openStream() throws IOException {
+                        return process.getErrorStream();
+                    }
+                }.read());
+
+                throw new IOException(format("Failed to determine MIME Type from %s (errout: %s)", uri, error));
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new IOException(format("Error inspecting MIME type using command %s", Arrays.asList(fileCmd)), e);
+        }
+    }
+}

--- a/src/test/java/com/afrozaar/util/graphicsmagick/MimeServiceTest.java
+++ b/src/test/java/com/afrozaar/util/graphicsmagick/MimeServiceTest.java
@@ -1,0 +1,25 @@
+package com.afrozaar.util.graphicsmagick;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.springframework.core.io.ClassPathResource;
+
+import org.junit.Test;
+
+public class MimeServiceTest {
+
+    MimeService mimeService = new MimeService();
+
+    @Test
+    public void getMimeType() throws Exception {
+        assertThat(mimeService.getMimeType(new ClassPathResource("/bin/Picture_600x400.jpg").getFile().getAbsolutePath())).isEqualTo("image/jpeg");
+        assertThat(mimeService.getMimeType(new ClassPathResource("/imageinfo.txt").getFile().getAbsolutePath())).isEqualTo("text/plain");
+        assertThat(mimeService.getMimeType(new ClassPathResource("/logback-test.xml").getFile().getAbsolutePath())).isEqualTo("text/plain");
+
+        for (int i = 0; i < 100; i++) {
+            assertThat(mimeService.getMimeType(new ClassPathResource("/logback-test.xml").getFile().getAbsolutePath())).isEqualTo("text/plain");
+        }
+
+    }
+
+}


### PR DESCRIPTION
This allows for smooth text from a PDF image. The PDF will be converted using a high (300dpi) resolution before resizing/cropping to the desired output size.