### PR TITLE
Implement making calls Resource Limits.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>util-graphicsmagick</artifactId>
     <name>GraphicsMagic Util</name>
-    <version>1.8.2</version>
+    <version>1.8.3-SNAPSHOT</version>
 
     <properties>
         <target>1.8</target>

--- a/src/main/java/com/afrozaar/util/graphicsmagick/GraphicsMagickImageIO.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/GraphicsMagickImageIO.java
@@ -143,9 +143,9 @@ public class GraphicsMagickImageIO extends AbstractImageIO {
         final GMBatchCommand batchCommand = new GMBatchCommand(service, command);
         final String uuid = UUID.randomUUID().toString();
 
-        LOG.debug("running operation {} (trace={})", op, uuid);
+        LOG.debug("Operating starting: {} {} (trace={})", command, op, uuid);
         batchCommand.run(op);
-        LOG.debug("Operation {} took {} (trace={})", op, Duration.of(System.currentTimeMillis() - start, ChronoUnit.MILLIS), uuid);
+        LOG.debug("Operation complete: {} {} took {} (trace={})", command, op, Duration.of(System.currentTimeMillis() - start, ChronoUnit.MILLIS), uuid);
     }
 
     private String runOperationWithOutput(String command, Operation operation) throws InterruptedException, IOException, IM4JavaException {
@@ -155,7 +155,7 @@ public class GraphicsMagickImageIO extends AbstractImageIO {
         batchCommand.setOutputConsumer(outputResult);
 
         batchCommand.run(operation);
-        LOG.debug("Operation {} {} took {}", command, operation, Duration.of(System.currentTimeMillis() - start, ChronoUnit.MILLIS));
+        LOG.debug("Operation with output: {} {} took {}", command, operation, Duration.of(System.currentTimeMillis() - start, ChronoUnit.MILLIS));
 
         return outputResult.getOutput();
     }

--- a/src/main/java/com/afrozaar/util/graphicsmagick/GraphicsMagickImageIO.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/GraphicsMagickImageIO.java
@@ -143,7 +143,7 @@ public class GraphicsMagickImageIO extends AbstractImageIO {
         final GMBatchCommand batchCommand = new GMBatchCommand(service, command);
         final String uuid = UUID.randomUUID().toString();
 
-        LOG.debug("Operating starting: {} {} (trace={})", command, op, uuid);
+        LOG.debug("Operation starting: {} {} (trace={})", command, op, uuid);
         batchCommand.run(op);
         LOG.debug("Operation complete: {} {} took {} (trace={})", command, op, Duration.of(System.currentTimeMillis() - start, ChronoUnit.MILLIS), uuid);
     }

--- a/src/main/java/com/afrozaar/util/graphicsmagick/GraphicsMagickImageIO.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/GraphicsMagickImageIO.java
@@ -11,7 +11,9 @@ import com.afrozaar.util.graphicsmagick.mime.MimeService;
 import com.afrozaar.util.graphicsmagick.operation.Convert;
 import com.afrozaar.util.graphicsmagick.operation.Identify;
 import com.afrozaar.util.graphicsmagick.operation.OutputResult;
+import com.afrozaar.util.graphicsmagick.util.RuntimeLimits;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
@@ -58,8 +60,15 @@ public class GraphicsMagickImageIO extends AbstractImageIO {
     private GMConnectionPoolConfig config = new GMConnectionPoolConfig();
 
     {
-        config.setMaxIdle(4);
-        config.setMaxActive(4);
+        if (RuntimeLimits.applyLimits()) {
+            config.setMaxIdle(4);
+            config.setMaxActive(4);
+        }
+
+        LOG.info("Initialised GraphicsMagickImageIO with config: {}", MoreObjects.toStringHelper(config)
+                .add("maxIdle", config.getMaxIdle())
+                .add("maxActive", config.getMaxActive())
+                .toString());
     }
 
     private GMService service = new PooledGMService(config);

--- a/src/main/java/com/afrozaar/util/graphicsmagick/api/IImageService.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/api/IImageService.java
@@ -6,13 +6,15 @@ import com.afrozaar.util.graphicsmagick.meta.MetaDataFormat;
 
 import com.google.common.io.ByteSource;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 public interface IImageService {
 
-    String resize(String tempImageLoc, int maximumHeight, int maximumWidth, String newSuffix, Double imageQuality) throws IOException;
+    String resize(String tempImageLoc, int maximumHeight, int maximumWidth, @Nullable String newSuffix, @Nullable Double imageQuality) throws IOException;
 
-    String resize(String tempImageLoc, int maximumHeight, int maximumWidth, String newSuffix) throws IOException;
+    String resize(String tempImageLoc, int maximumHeight, int maximumWidth, @Nullable String newSuffix) throws IOException;
 
     String crop(String templateImageLoc, XY size, XY offsets, XY resizeXY, String newSuffix) throws IOException;
 

--- a/src/main/java/com/afrozaar/util/graphicsmagick/api/IImageService.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/api/IImageService.java
@@ -18,7 +18,7 @@ public interface IImageService {
 
     String crop(String templateImageLoc, XY size, XY offsets, XY resizeXY, String newSuffix) throws IOException;
 
-    String crop(String templateImageLoc, XY size, XY offsets, XY resizeXY, String newSuffix, Double imageQuality) throws IOException;
+    String crop(String templateImageLoc, XY size, XY offsets, XY resizeXY, String newSuffix, @Nullable Double imageQuality) throws IOException;
 
     ByteSource loadImage(String tempImageLoc);
 

--- a/src/main/java/com/afrozaar/util/graphicsmagick/operation/Convert.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/operation/Convert.java
@@ -1,0 +1,37 @@
+package com.afrozaar.util.graphicsmagick.operation;
+
+import static java.util.Optional.ofNullable;
+
+import com.afrozaar.util.graphicsmagick.data.ImageInfo;
+
+import org.im4java.core.IMOperation;
+import org.im4java.core.Operation;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * @author johan
+ */
+public class Convert {
+
+    public static String COMMAND = "convert";
+
+    public static Operation createImOperation(String tempImageLoc, ImageInfo imageInfo, @Nullable Double imageQuality) throws IOException {
+        IMOperation op = new IMOperation();
+        op.limit("threads").addRawArgs("2");
+
+        if ("application/pdf".equalsIgnoreCase(imageInfo.getMimeType())) {
+            op.density(300);
+        }
+
+        op.strip();
+        op.addImage(tempImageLoc);
+
+        ofNullable(imageQuality).ifPresent(op::quality);
+
+        op.colorspace("rgb");
+        return op;
+    }
+}

--- a/src/main/java/com/afrozaar/util/graphicsmagick/operation/Convert.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/operation/Convert.java
@@ -3,6 +3,7 @@ package com.afrozaar.util.graphicsmagick.operation;
 import static java.util.Optional.ofNullable;
 
 import com.afrozaar.util.graphicsmagick.data.ImageInfo;
+import com.afrozaar.util.graphicsmagick.util.RuntimeLimits;
 
 import org.im4java.core.IMOperation;
 import org.im4java.core.Operation;
@@ -20,7 +21,10 @@ public class Convert {
 
     public static Operation createImOperation(String tempImageLoc, ImageInfo imageInfo, @Nullable Double imageQuality) throws IOException {
         IMOperation op = new IMOperation();
-        op.limit("threads").addRawArgs("2");
+
+        if (RuntimeLimits.applyLimits()) {
+            op.limit("threads").addRawArgs("2");
+        }
 
         if ("application/pdf".equalsIgnoreCase(imageInfo.getMimeType())) {
             op.density(300);

--- a/src/main/java/com/afrozaar/util/graphicsmagick/operation/Identify.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/operation/Identify.java
@@ -1,0 +1,43 @@
+package com.afrozaar.util.graphicsmagick.operation;
+
+import org.im4java.core.GMOperation;
+import org.im4java.core.IM4JavaException;
+import org.im4java.core.Operation;
+
+import java.io.IOException;
+
+public class Identify {
+
+    public static final String COMMAND = "identify";
+    static final String IDENTIFY_FORMAT = "width=%w\\nheight=%h\\ntype=%m\\nname=%t\\n";
+
+    /**
+     * -----
+     * >$ identify -format "width=%w\nheight=%h\ntype=%m\nname=%t\n" maxi.jpg
+     * >width=1024
+     * >height=768
+     * >type=JPEG
+     * >name=maxi
+     * ----
+     *
+     * NOTE: type is not the full MIME format: &lt;base_type&gt;/&lt;subtype&gt;
+     */
+    public static Operation identify(String tempImageLoc) throws InterruptedException, IOException, IM4JavaException {
+        GMOperation identifyOp = new GMOperation();
+        identifyOp.limit("threads").addRawArgs("1");
+        identifyOp.addRawArgs("-format", IDENTIFY_FORMAT);
+        identifyOp.addImage(tempImageLoc);
+
+        return identifyOp;
+    }
+
+    public static Operation identifyVerbose(String tempImageLoc) throws InterruptedException, IOException, IM4JavaException {
+        GMOperation identifyOp = new GMOperation();
+        identifyOp.verbose();
+        identifyOp.limit("threads").addRawArgs("1");
+        identifyOp.addImage(tempImageLoc);
+
+        return identifyOp;
+    }
+
+}

--- a/src/main/java/com/afrozaar/util/graphicsmagick/operation/Identify.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/operation/Identify.java
@@ -1,5 +1,7 @@
 package com.afrozaar.util.graphicsmagick.operation;
 
+import com.afrozaar.util.graphicsmagick.util.RuntimeLimits;
+
 import org.im4java.core.GMOperation;
 import org.im4java.core.IM4JavaException;
 import org.im4java.core.Operation;
@@ -24,7 +26,11 @@ public class Identify {
      */
     public static Operation identify(String tempImageLoc) throws InterruptedException, IOException, IM4JavaException {
         GMOperation identifyOp = new GMOperation();
-        identifyOp.limit("threads").addRawArgs("1");
+
+        if (RuntimeLimits.applyLimits()) {
+            identifyOp.limit("threads").addRawArgs("1");
+        }
+
         identifyOp.addRawArgs("-format", IDENTIFY_FORMAT);
         identifyOp.addImage(tempImageLoc);
 
@@ -34,7 +40,11 @@ public class Identify {
     public static Operation identifyVerbose(String tempImageLoc) throws InterruptedException, IOException, IM4JavaException {
         GMOperation identifyOp = new GMOperation();
         identifyOp.verbose();
-        identifyOp.limit("threads").addRawArgs("1");
+
+        if (RuntimeLimits.applyLimits()) {
+            identifyOp.limit("threads").addRawArgs("1");
+        }
+
         identifyOp.addImage(tempImageLoc);
 
         return identifyOp;

--- a/src/main/java/com/afrozaar/util/graphicsmagick/operation/OutputResult.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/operation/OutputResult.java
@@ -1,0 +1,21 @@
+package com.afrozaar.util.graphicsmagick.operation;
+
+import org.apache.commons.io.IOUtils;
+import org.im4java.process.OutputConsumer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class OutputResult implements OutputConsumer {
+        private String output;
+
+        public String getOutput() {
+            return output;
+        }
+
+        @Override
+        public void consumeOutput(InputStream inputStream) throws IOException {
+            output = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        }
+    }

--- a/src/main/java/com/afrozaar/util/graphicsmagick/util/GMInfo.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/util/GMInfo.java
@@ -16,7 +16,7 @@ public class GMInfo {
         try {
             final Process exec = Runtime.getRuntime().exec("gm convert -list resource");
 
-            if (exec.waitFor(100, TimeUnit.MILLISECONDS)) {
+            if (exec.waitFor(1L, TimeUnit.SECONDS)) {
                 return IOUtils.toString(exec.getInputStream(), StandardCharsets.UTF_8);
             } else {
                 return IOUtils.toString(exec.getErrorStream(), StandardCharsets.UTF_8);

--- a/src/main/java/com/afrozaar/util/graphicsmagick/util/GMInfo.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/util/GMInfo.java
@@ -1,0 +1,28 @@
+package com.afrozaar.util.graphicsmagick.util;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+public class GMInfo {
+
+    private GMInfo() {
+
+    }
+
+    public static String getEnvironmentInfo() throws IOException {
+        try {
+            final Process exec = Runtime.getRuntime().exec("gm convert -list resource");
+
+            if (exec.waitFor(100, TimeUnit.MILLISECONDS)) {
+                return IOUtils.toString(exec.getInputStream(), StandardCharsets.UTF_8);
+            } else {
+                return IOUtils.toString(exec.getErrorStream(), StandardCharsets.UTF_8);
+            }
+        } catch (InterruptedException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/afrozaar/util/graphicsmagick/util/RuntimeLimits.java
+++ b/src/main/java/com/afrozaar/util/graphicsmagick/util/RuntimeLimits.java
@@ -1,0 +1,14 @@
+package com.afrozaar.util.graphicsmagick.util;
+
+public class RuntimeLimits {
+
+    public static final String GM_APPLYLIMITS = "gm.limitresources";
+
+    private RuntimeLimits() {
+
+    }
+
+    public static boolean applyLimits() {
+        return Boolean.getBoolean(GM_APPLYLIMITS);
+    }
+}

--- a/src/test/java/com/afrozaar/util/graphicsmagick/GraphicsMagickImageIOTest.java
+++ b/src/test/java/com/afrozaar/util/graphicsmagick/GraphicsMagickImageIOTest.java
@@ -1,0 +1,30 @@
+package com.afrozaar.util.graphicsmagick;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * @author johan
+ */
+public class GraphicsMagickImageIOTest {
+
+    @Test
+    public void resizePdf() throws IOException {
+        GraphicsMagickImageIO gmio = new GraphicsMagickImageIO();
+
+        Resource resource = new ClassPathResource("/bin/pdf/Business.pdf");
+
+        String tmpLoc = resource.getFile().getAbsolutePath();
+
+        System.out.println("tmpLoc = " + tmpLoc);
+
+        final String png = gmio.resize(tmpLoc, 1000, 1000, "png");
+
+        System.out.println("png = " + png);
+    }
+
+}

--- a/src/test/java/com/afrozaar/util/graphicsmagick/util/GMInfoTest.java
+++ b/src/test/java/com/afrozaar/util/graphicsmagick/util/GMInfoTest.java
@@ -1,0 +1,17 @@
+package com.afrozaar.util.graphicsmagick.util;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * @author johan
+ */
+public class GMInfoTest {
+
+    @Test
+    public void getEnvInfo() throws IOException {
+        System.out.println("new GMInfo().getEnvironmentInfo() = \n" + GMInfo.getEnvironmentInfo());
+    }
+
+}


### PR DESCRIPTION
When processing PDF resources, it became clear that environments with limited resources do struggle to complete with the GraphicsMagic default calls.

This change added the ability to specify on startup whether limitations should be applied.

The limitations include setting the GM batch size to max 4 (default=8) and idle 4 (default=8), as well as making calls to convert and identify with limits of 2 and 1 threads respectively.